### PR TITLE
Added custom TypeConverter support.

### DIFF
--- a/MadMilkman.Ini/IniItems/IniKey.cs
+++ b/MadMilkman.Ini/IniItems/IniKey.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Collections.Generic;
+using System.ComponentModel;
 
 namespace MadMilkman.Ini
 {


### PR DESCRIPTION
Now you can do this to attach custom type converter to property which should be serialized/deserizalized using target type converter:

``` c#
public class SomeSettings
{
    [TypeConverter(typeof(MyCustomClassConverter))]
    public MyCustomClass CustomClassProperty { get; set; }
}
```

Implementation is a bit unefficient because everytime you serialize/deserialize property a new TypeConverter instance is being created as well as empty array to pass into TypeConverter constructor.

Resolves #5.
